### PR TITLE
Actualizar link obsoleto a descarga de dependencia

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ error while loading shared libraries: libssl.so.1.1: cannot open shared object f
 Solución 
 
 ~~~
-wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.17_amd64.deb
+wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.18_amd64.deb
 
-sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2.17_amd64.deb
+sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2.18_amd64.deb
 ~~~
 
 


### PR DESCRIPTION
Link actual http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.17_amd64.deb no resuelve (404)

![image](https://github.com/Noisk8/montando_nodo_nym/assets/89636253/f8b45aa2-b818-47aa-82a8-61e166b5f732)


Cambiar el link por la versión inmediatamente superior, link disponible: http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.18_amd64.deb